### PR TITLE
Fix issue with incorrect LED polarity on LoRa-E5 mini board

### DIFF
--- a/Core/Inc/board_resources.h
+++ b/Core/Inc/board_resources.h
@@ -36,6 +36,15 @@ extern "C" {
 
 /* Exported types ------------------------------------------------------------*/
 /**
+  * @brief Led polarity
+  */
+typedef enum
+{
+  LED_POLARITY_ACTIVE_LOW = 0,
+  LED_POLARITY_ACTIVE_HIGH
+} Led_Polarity_TypeDef;
+
+/**
   * @brief Led enumeration
   */
 typedef enum
@@ -81,6 +90,11 @@ typedef enum
   * @brief Port of Led2
   */
 #define SYS_LED2_GPIO_PORT                          GPIOB
+/**
+  * @brief Polarity of LED
+  */
+#define SYS_LED2_POLARITY                           LED_POLARITY_ACTIVE_LOW
+
 /**
   * @brief Enable GPIOs clock of Led2
   */

--- a/Core/Src/board_resources.c
+++ b/Core/Src/board_resources.c
@@ -65,6 +65,11 @@ static GPIO_TypeDef  *SYS_LED_PORT[SYS_LEDn] = {SYS_LED2_GPIO_PORT, };
 static const uint16_t SYS_LED_PIN[SYS_LEDn] = {SYS_LED2_PIN, };
 
 /**
+  * @brief Polarity led list
+  */
+static const uint8_t SYS_LED_POLARITY[SYS_LEDn] = {SYS_LED2_POLARITY, };
+
+/**
   * @brief Ports button list
   */
 static GPIO_TypeDef   *SYS_BUTTON_PORT[SYS_BUTTONn] = {SYS_BUTTON1_GPIO_PORT, };
@@ -103,7 +108,7 @@ int32_t SYS_LED_Init(Sys_Led_TypeDef Led)
   gpio_init_structure.Speed = GPIO_SPEED_FREQ_HIGH;
 
   HAL_GPIO_Init(SYS_LED_PORT[Led], &gpio_init_structure);
-  HAL_GPIO_WritePin(SYS_LED_PORT[Led], SYS_LED_PIN[Led], GPIO_PIN_RESET);
+  HAL_GPIO_WritePin(SYS_LED_PORT[Led], SYS_LED_PIN[Led], (SYS_LED_POLARITY[Led] == LED_POLARITY_ACTIVE_HIGH) ? GPIO_PIN_RESET : GPIO_PIN_SET);
 
   return 0;
 }
@@ -111,7 +116,7 @@ int32_t SYS_LED_Init(Sys_Led_TypeDef Led)
 int32_t SYS_LED_DeInit(Sys_Led_TypeDef Led)
 {
   /* Turn off SYS_LED */
-  HAL_GPIO_WritePin(SYS_LED_PORT[Led], SYS_LED_PIN[Led], GPIO_PIN_RESET);
+  HAL_GPIO_WritePin(SYS_LED_PORT[Led], SYS_LED_PIN[Led], (SYS_LED_POLARITY[Led] == LED_POLARITY_ACTIVE_HIGH) ? GPIO_PIN_RESET : GPIO_PIN_SET);
 
   /* DeInit the GPIO_SYS_LED pin */
   HAL_GPIO_DeInit(SYS_LED_PORT[Led], SYS_LED_PIN[Led]);
@@ -121,14 +126,14 @@ int32_t SYS_LED_DeInit(Sys_Led_TypeDef Led)
 
 int32_t SYS_LED_On(Sys_Led_TypeDef Led)
 {
-  HAL_GPIO_WritePin(SYS_LED_PORT[Led], SYS_LED_PIN[Led], GPIO_PIN_SET);
+  HAL_GPIO_WritePin(SYS_LED_PORT[Led], SYS_LED_PIN[Led], (SYS_LED_POLARITY[Led] == LED_POLARITY_ACTIVE_HIGH) ? GPIO_PIN_SET : GPIO_PIN_RESET);
 
   return 0;
 }
 
 int32_t SYS_LED_Off(Sys_Led_TypeDef Led)
 {
-  HAL_GPIO_WritePin(SYS_LED_PORT[Led], SYS_LED_PIN[Led], GPIO_PIN_RESET);
+  HAL_GPIO_WritePin(SYS_LED_PORT[Led], SYS_LED_PIN[Led], (SYS_LED_POLARITY[Led] == LED_POLARITY_ACTIVE_HIGH) ? GPIO_PIN_RESET : GPIO_PIN_SET);
 
   return 0;
 }


### PR DESCRIPTION
The functions that control the single LED on the LoRa-E5 Mini board have the polarity reversed. They assume PB5 is sourcing current to the LED, not sinking it. This PR corrects that and allows the user to specify the LED polarity as part of the configuration, much the same way the pin and port configuration works.

This PR does not address the fact that the LED is actually red, instead of the blue that the code calls out.